### PR TITLE
Adjust ActiveTriples & linked_vocabs dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'active-triples', :git => 'https://github.com/no-reply/ActiveTriples.git', :branch => 'feature/validations-2'

--- a/dpla_map.gemspec
+++ b/dpla_map.gemspec
@@ -12,21 +12,14 @@ Gem::Specification.new do |s|
   s.description = %q{DPLA's metadata application profile in ActiveTriples.}
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency('active-triples')
-  s.add_dependency('linked_vocabs')
-
-  s.add_development_dependency('pry')
-  s.add_development_dependency('rspec')
-  s.add_development_dependency('factory_girl', '~> 4.0')
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.require_paths = ['lib', 'lib/dpla', 'lib/dpla/map', 'lib/rdf']
 
-  s.add_dependency 'active-triples'
-  s.add_dependency 'linked_vocabs', '~>0.1.0'
+  s.add_dependency 'active-triples', '~>0.3'
+  s.add_dependency 'linked_vocabs', '~>0.1'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Loosen pessimistic dependency on linked_vocabs to accept pre-1.0 versions. Push ActiveTriples to ~>0.3.0.
