### PR TITLE
Only setup factory linting if RSpec is defined

### DIFF
--- a/lib/dpla/map/factories.rb
+++ b/lib/dpla/map/factories.rb
@@ -75,8 +75,10 @@ FactoryGirl.define do
   end
 end
 
-RSpec.configure do |config|
-  config.before(:suite) do
-    FactoryGirl.lint
+if defined?(RSpec)
+  RSpec.configure do |config|
+    config.before(:suite) do
+      FactoryGirl.lint
+    end
   end
 end


### PR DESCRIPTION
Makes it possible to use factories in a context outside of RSpec, e.g. in a Rake task, or at the console.
