### PR TITLE
Rename dc:format property to dcformat (fixes #11)

### DIFF
--- a/lib/dpla/map/factories.rb
+++ b/lib/dpla/map/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     date { |timespan| timespan.association :timespan, :strategy => :build }
     description 'Window of the Stonewall Bar N.Y. 1969. The other half of the graffiti was erased by the time Diana photographed it.'
     extent '10x12 cm'
-    format 'Silver Gelatin Print'
+    dcformat 'Silver Gelatin Print'
     genre { |genre| genre.association :genre, :strategy => :build }
     identifier '510d47e3-57d2-a3d9-e040-e00a18064a99'
     language { |language| language.association :language, :strategy => :build }
@@ -41,7 +41,7 @@ FactoryGirl.define do
   end
 
   factory :web_resource, class: DPLA::MAP::WebResource do
-    format 'image/tiff'
+    dcformat 'image/tiff'
     rights 'Public Domain'
     rightsStatement { ActiveTriples::Resource.new('http://creativecommons.org/publicdomain/mark/1.0/') }
 

--- a/lib/dpla/map/source_resource.rb
+++ b/lib/dpla/map/source_resource.rb
@@ -12,7 +12,7 @@ module DPLA::MAP
     property :date, :predicate => RDF::DC11.date, :class_name => 'DPLA::MAP::TimeSpan'
     property :description, :predicate => RDF::DC.description
     property :extent, :predicate => RDF::DC.extent
-    property :format, :predicate => RDF::DC11.format
+    property :dcformat, :predicate => RDF::DC11.format
     property :genre, :predicate => RDF::EDM.hasType, :class_name => 'DPLA::MAP::Controlled::Genre'
     property :identifier, :predicate => RDF::DC11.identifier
     property :language, :predicate => RDF::DC.language, :class_name => 'DPLA::MAP::Controlled::Language'

--- a/lib/dpla/map/web_resource.rb
+++ b/lib/dpla/map/web_resource.rb
@@ -2,7 +2,7 @@ module DPLA::MAP
   class WebResource < ActiveTriples::Resource
     configure :type => RDF::EDM.WebResource
 
-    property :format, :predicate => RDF::DC11.format
+    property :dcformat, :predicate => RDF::DC11.format
     property :rights, :predicate => RDF::DC11.rights
     property :rightsStatement, :predicate => RDF::EDM.rights, :class_name => 'DPLA::MAP::RightsStatement'
   end


### PR DESCRIPTION
The `dc:format` property definition used the name `:format`, which conflicts with the [Kernel #format method](http://www.ruby-doc.org/core-2.1.5/Kernel.html#method-i-format). This changes the property definition to use `:dcformat`.