### PR TITLE
Prepare 4.0.0.0.pre.10 release

### DIFF
--- a/dpla-map.gemspec
+++ b/dpla-map.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib', 'lib/dpla', 'lib/dpla/map', 'lib/rdf']
 
-  s.add_dependency 'active-triples', '~>0.3'
-  s.add_dependency 'linked_vocabs', '~>0.1'
+  s.add_dependency 'active-triples', '~>0.6.0'
+  s.add_dependency 'linked_vocabs', '~>0.2.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'

--- a/lib/dpla/map/version.rb
+++ b/lib/dpla/map/version.rb
@@ -1,5 +1,5 @@
 module DPLA
   module MAP
-    VERSION = '4.0.0.0.pre.9'
+    VERSION = '4.0.0.0.pre.10'
   end
 end


### PR DESCRIPTION
Bumps dependencies on ActiveTriples & linked_vocabs.