### PR TITLE
Fix: DPLA::MAP::SourceResource#language getter returns empty array

### DIFF
--- a/lib/dpla/map/controlled/language.rb
+++ b/lib/dpla/map/controlled/language.rb
@@ -3,11 +3,11 @@ module DPLA::MAP
     class Language < DPLA::MAP::Concept
       include LinkedVocabs::Controlled
 
-      configure :base_uri => "http://lexvo.org/id/iso639-3/", :rdf_label => RDF::URI('http://www.w3.org/2008/05/skos#prefLabel')
+      configure :base_uri => "http://lexvo.org/id/iso639-3/", 
+                :rdf_label => RDF::SKOS.prefLabel,
+                :type => RDF::DC.LinguisticSystem
 
       use_vocabulary :iso_639_3
-
-      property :prefLabel, :predicate => RDF::SKOS.prefLabel
     end
   end
 end

--- a/spec/lib/dpla_spec.rb
+++ b/spec/lib/dpla_spec.rb
@@ -8,5 +8,19 @@ describe DPLA::MAP::SourceResource do
     expect(subject.type).to eq [RDF::URI('http://dp.la/about/map/SourceResource')]
   end
 
-end
+  it 'has an edm:hasType that is a DPLA::MAP::Controlled::Genre' do
+    expect(subject.genre).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::Genre))
+  end
 
+  it 'has a dcterms:language that is a DPLA::MAP::Controlled::Language' do
+    expect(subject.language).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::Language))
+  end
+
+  it 'has a dcterms:subject that is a DPLA::MAP::Concept' do
+    expect(subject.subject).to contain_exactly(an_instance_of(DPLA::MAP::Concept))
+  end
+
+  it 'has a dcterms:type that is a DPLA::MAP::Controlled::DCMIType' do
+    expect(subject.dctype).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::DCMIType))
+  end
+end


### PR DESCRIPTION
This starts by adding specs, including a failing spec for `DPLA::MAP::SourceResource#language`. The additional specs are not meant to be exhaustive, but rather complementary to demonstrate this is not an issue with DPLA::MAP::Concept or its subclasses.