### PR TITLE
Remove LinkedVocabs

### DIFF
--- a/dpla-map.gemspec
+++ b/dpla-map.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib', 'lib/dpla', 'lib/dpla/map', 'lib/rdf']
 
   s.add_dependency 'active-triples', '~>0.6.0'
-  s.add_dependency 'linked_vocabs', '~>0.2.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'

--- a/lib/dpla/map.rb
+++ b/lib/dpla/map.rb
@@ -1,8 +1,8 @@
 require 'active_triples'
-require 'linked_vocabs'
 
 require 'date'
 
+require 'rdf/turtle'
 require 'rdf/dpla'
 
 require 'rdf/aat'
@@ -15,11 +15,6 @@ require 'rdf/ore'
 
 module DPLA
   module MAP
-    LinkedVocabs.add_vocabulary(:aat, 'http://vocab.getty.edu/aat/')
-    LinkedVocabs.add_vocabulary(:iso_639_3, 'http://lexvo.org/id/iso639-3/')
-    LinkedVocabs.add_vocabulary(:gn, 'http://www.geonames.org/ontology#', :source => 'http://www.geonames.org/ontology/ontology_v3.1.rdf', :fetch => true)
-
-
     autoload :SourceResource,     'dpla/map/source_resource'
     autoload :Collection,         'dpla/map/collection'
     autoload :Place,              'dpla/map/place'

--- a/lib/dpla/map/controlled/dcmitype.rb
+++ b/lib/dpla/map/controlled/dcmitype.rb
@@ -1,10 +1,8 @@
 module DPLA::MAP
   module Controlled
     class DCMIType < DPLA::MAP::Concept
-      include LinkedVocabs::Controlled
-      configure :type => RDF::RDFS.Class
-
-      use_vocabulary :dcmitype
+        configure :type => RDF::RDFS.Class, 
+                  :base_uri => RDF::URI('http://purl.org/dc/dcmitype/')
     end
   end
 end

--- a/lib/dpla/map/controlled/genre.rb
+++ b/lib/dpla/map/controlled/genre.rb
@@ -1,11 +1,7 @@
 module DPLA::MAP
   module Controlled
     class Genre < DPLA::MAP::Concept
-      include LinkedVocabs::Controlled
-      
       configure :base_uri => 'http://vocab.getty.edu/aat/', :type => 'http://vocab.getty.edu/ontology#Concept'
-      
-      use_vocabulary :aat
     end
   end
 end

--- a/lib/dpla/map/controlled/language.rb
+++ b/lib/dpla/map/controlled/language.rb
@@ -1,13 +1,9 @@
 module DPLA::MAP
   module Controlled
     class Language < DPLA::MAP::Concept
-      include LinkedVocabs::Controlled
-
       configure :base_uri => "http://lexvo.org/id/iso639-3/", 
                 :rdf_label => RDF::SKOS.prefLabel,
                 :type => RDF::DC.LinguisticSystem
-
-      use_vocabulary :iso_639_3
     end
   end
 end

--- a/lib/dpla/map/source_resource.rb
+++ b/lib/dpla/map/source_resource.rb
@@ -3,7 +3,6 @@ module DPLA::MAP
     configure :base_uri => 'http://dp.la/api/items/', :type => RDF::DPLA.SourceResource
 
     validates_presence_of :rights, :title
-    validates_vocabulary_of :dctype, :genre, :language
 
     property :alternative, :predicate => RDF::DC.alternative
     property :collection, :predicate => RDF::DC.isPartOf, :class_name => 'DPLA::MAP::Collection'

--- a/spec/lib/dpla_spec.rb
+++ b/spec/lib/dpla_spec.rb
@@ -24,3 +24,34 @@ describe DPLA::MAP::SourceResource do
     expect(subject.dctype).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::DCMIType))
   end
 end
+
+describe DPLA::MAP::Aggregation do
+  subject { build(:aggregation) }
+
+  it 'has nested values' do
+    expect(subject.sourceResource.first.subject.first.prefLabel)
+      .to contain_exactly('Gay activists')
+  end
+  
+  context 'when built from parsed graph' do
+    let(:parsed) do
+      lang = DPLA::MAP::Controlled::Language.new
+      lang.providedLabel = label
+      subject.sourceResource.first.language = lang
+
+      uri = RDF::URI('http://example.org/moomin')
+      subject.set_subject!(uri)
+
+      agg = DPLA::MAP::Aggregation.new(uri)
+      agg << RDF::Reader.for(:ttl).new(subject.dump(:ttl))
+      agg
+    end
+
+    let(:label) { 'eng' }
+
+    it 'has nested values' do
+      expect(parsed.sourceResource.first.language.first.providedLabel)
+        .to contain_exactly(label)
+    end
+  end
+end


### PR DESCRIPTION
LinkedVocabs introduced a bug surrounding blank node identity, causing
new nodes to be minted in cases where the node is not already in the
cache (e.g. when the graph has been loaded from turtle).

Rather than waiting for a LinkedVocabs patch, this simply removes it,
since we aren't using the validation features anyway.

I made some minor generalizing changes to a pair of Krikri enrichments to move them away from reliance on LinkedVocabs. Krikri is already tightly pinned to a specific MAP version, so an update and release would be needed anyhow.
