### PR TITLE
Allow skos:prefLabel on edm:TimeSpan (ref #8228)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: ruby
 bundler_args: --without debug
+sudo: false
+before_install: gem install -v '~> 1.10' bundler
 script: "bundle exec rspec spec"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.1.1
   - 2.1.3
+  - 2.1.6
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+  - ruby-head
 

--- a/dpla-map.gemspec
+++ b/dpla-map.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
   s.add_development_dependency 'factory_girl', '~>4.4.0'
+  s.add_development_dependency 'bundler', '~> 1.10'
 end

--- a/lib/dpla/map/time_span.rb
+++ b/lib/dpla/map/time_span.rb
@@ -4,6 +4,7 @@ module DPLA::MAP
     
     validates_presence_of :providedLabel
 
+    property :prefLabel, :predicate => RDF::SKOS.prefLabel
     property :providedLabel, :predicate => RDF::DPLA.providedLabel    
     property :begin, :predicate => RDF::EDM.begin
     property :end, :predicate => RDF::EDM.end

--- a/spec/lib/dpla_spec.rb
+++ b/spec/lib/dpla_spec.rb
@@ -12,6 +12,10 @@ describe DPLA::MAP::SourceResource do
     expect(subject.genre).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::Genre))
   end
 
+  it 'has a dc:date that is a DPLA::MAP::TimeSpan' do
+    expect(subject.date).to contain_exactly(an_instance_of(DPLA::MAP::TimeSpan))
+  end
+
   it 'has a dcterms:language that is a DPLA::MAP::Controlled::Language' do
     expect(subject.language).to contain_exactly(an_instance_of(DPLA::MAP::Controlled::Language))
   end
@@ -31,6 +35,8 @@ describe DPLA::MAP::Aggregation do
   it 'has nested values' do
     expect(subject.sourceResource.first.subject.first.prefLabel)
       .to contain_exactly('Gay activists')
+    expect(subject.sourceResource.first.date.first.providedLabel)
+      .to contain_exactly('1969.')
   end
   
   context 'when built from parsed graph' do


### PR DESCRIPTION
- Explicitly allow `skos:prefLabel` on `edm:TimeSpan`, so `#prefLabel` and `#prefLabel=` can be used.
- Add an example that confirms a typed dc:date is an instance of `DPLA::MAP::TimeSpan`, and confirm that the instance gets its dpla:providedLabel gets set correctly

Refs [#8228](https://issues.dp.la/issues/8228), since I'd be using `#prefLabel=` to write the failing spec. 
