### PR TITLE
Align Rubies in CI with KriKri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ sudo: false
 before_install: gem install -v '~> 1.10' bundler
 script: "bundle exec rspec spec"
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.3
   - 2.1.6
-  - 2.1.8
-  - 2.2.4
+  - 2.2.3
   - 2.3.0
-  - ruby-head
-

--- a/dpla-map.gemspec
+++ b/dpla-map.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = 'tom@dp.la'
   s.summary     = %q{DPLA's metadata application profile in ActiveTriples.}
   s.description = %q{DPLA's metadata application profile in ActiveTriples.}
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.0.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Drops support for Ruby 1.9.3.

Support was dropped by the Ruby core team some time ago, and by RDF.rb in spring of last year. The Rubies used in CI are updated to be in alignment with KriKri.
